### PR TITLE
✏️ Fix "Steve McClellan" -> "Steve McConnell"

### DIFF
--- a/lectures/tdd/Testing_and_design.ipynb
+++ b/lectures/tdd/Testing_and_design.ipynb
@@ -69,7 +69,7 @@
     }
    },
    "source": [
-    "- many estimates for error rates are scary: a widely-cited statistic (*Code Complete* by Steve McClellan) gives an industry average of 15-50 bugs per 1000 lines of *delivered* code."
+    "- many estimates for error rates are scary: a widely-cited statistic (*Code Complete* by Steve McConnell) gives an industry average of 15-50 bugs per 1000 lines of *delivered* code."
    ]
   },
   {


### PR DESCRIPTION
Small typo fix, Steve McConnell authored [Code Complete](https://en.wikipedia.org/wiki/Code_Complete).